### PR TITLE
New API to support the GraphQL multipart request spec v2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+* New API to support the [GraphQL multipart request spec v2.0.0-alpha.2](https://github.com/jaydenseric/graphql-multipart-request-spec/releases/tag/v2.0.0-alpha.2). Files no longer upload to the filesystem; [readable streams](https://nodejs.org/api/stream.html#stream_readable_streams) are used in resolvers instead.
+* Export a new `Upload` scalar type to use in place of the old `Upload` input type. It represents a file upload promise that resolves an object containing `stream`, `filename`, `mimetype` and `encoding`.
+* Deprecated the `uploadDir` middleware option.
+* Added new `maxFieldSize`, `maxFileSize` and `maxFiles` middleware options.
+* `graphql` is now a peer dependency.
 * Middleware are now arrow functions.
 
 ## 3.0.0

--- a/package.json
+++ b/package.json
@@ -33,9 +33,11 @@
     "node": ">=7.6"
   },
   "dependencies": {
-    "formidable": "^1.1.1",
-    "mkdirp": "^0.5.1",
+    "busboy": "^0.2.14",
     "object-path": "^0.11.4"
+  },
+  "peerDependencies": {
+    "graphql": "^0.11.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.32",
@@ -43,6 +45,7 @@
     "@babel/preset-env": "^7.0.0-beta.32",
     "eslint": "^4.11.0",
     "eslint-plugin-prettier": "^2.3.1",
+    "graphql": "^0.11.7",
     "husky": "^0.14.3",
     "lint-staged": "^5.0.0",
     "prettier": "^1.8.2"


### PR DESCRIPTION
* New API to support the [GraphQL multipart request spec v2.0.0-alpha.2](https://github.com/jaydenseric/graphql-multipart-request-spec/releases/tag/v2.0.0-alpha.2). Files no longer upload to the filesystem; [readable streams](https://nodejs.org/api/stream.html#stream_readable_streams) are used in resolvers instead. Fixes [#13](https://github.com/jaydenseric/apollo-upload-server/issues/13).
* Export a new `Upload` scalar type to use in place of the old `Upload` input type. It represents a file upload promise that resolves an object containing `stream`, `filename`, `mimetype` and `encoding`.
* `graphql` is now a peer dependency.
* Deprecated the `uploadDir` middleware option.
* Added new `maxFieldSize`, `maxFileSize` and `maxFiles` middleware options.