### PR TITLE
Make Examples section more clear, visual

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,9 @@ Once setup, on the client use [`FileList`](https://developer.mozilla.org/en/docs
 
 Files upload via a [GraphQL multipart request](https://github.com/jaydenseric/graphql-multipart-request-spec) and appear as [`Upload` scalars](#upload-scalar) in resolver arguments.
 
-See the [example API and client](https://github.com/jaydenseric/apollo-upload-examples).
+## Examples
+
+Find server and client side examples in the the [apollo-upload-examples](https://github.com/jaydenseric/apollo-upload-examples) repository.
 
 ## Support
 


### PR DESCRIPTION
If the README would look like this chances are I would notice the server side code examples myself. :)