### PR TITLE
Adding support for Blob types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # apollo-upload-server changelog
 
-## 4.0.0-alpha.4
+## Next
 
 * Updated readme to include Blob type info
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # apollo-upload-server changelog
 
+## 4.0.0-alpha.4
+
+* Updated readme to include Blob type info
+
 ## 4.0.0-alpha.3
 
 * Updated dependencies.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-* Updated readme to include Blob type info
+* Documented [`Blob`](https://developer.mozilla.org/en/docs/Web/API/Blob) types, via [#39](https://github.com/jaydenseric/apollo-upload-server/pull/39).
 
 ## 4.0.0-alpha.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-upload-server",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-alpha.4",
   "description": "Enhances Apollo GraphQL Server for intuitive file uploads via GraphQL mutations.",
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-upload-server",
-  "version": "4.0.0-alpha.4",
+  "version": "4.0.0-alpha.3",
   "description": "Enhances Apollo GraphQL Server for intuitive file uploads via GraphQL mutations.",
   "license": "MIT",
   "author": {

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ Also setup [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-c
 
 ## Usage
 
-Once setup, on the client use [`FileList`](https://developer.mozilla.org/en/docs/Web/API/FileList), [`File`](https://developer.mozilla.org/en/docs/Web/API/File) and [`ReactNativeFile`](https://github.com/jaydenseric/apollo-upload-client#react-native) instances anywhere within query or mutation input variables. See the [client usage](https://github.com/jaydenseric/apollo-upload-client#usage).
+Once setup, on the client use [`FileList`](https://developer.mozilla.org/en/docs/Web/API/FileList), [`File`](https://developer.mozilla.org/en/docs/Web/API/File), [`Blob`](https://developer.mozilla.org/en/docs/Web/API/Blob) and [`ReactNativeFile`](https://github.com/jaydenseric/apollo-upload-client#react-native) instances anywhere within query or mutation input variables. See the [client usage](https://github.com/jaydenseric/apollo-upload-client#usage).
 
 Files upload via a [GraphQL multipart request](https://github.com/jaydenseric/graphql-multipart-request-spec) and appear as [`Upload` scalars](#upload-scalar) in resolver arguments.
 


### PR DESCRIPTION
Support for Blob type has been added.

PRs have also been sent for extract-files, apollo-upload-client and apollo-upload-examples.