### PR TITLE
Allow customization of Upload GraphQL type

### DIFF
--- a/src/types.mjs
+++ b/src/types.mjs
@@ -1,15 +1,21 @@
 import { GraphQLScalarType } from 'graphql'
 
-export const GraphQLUpload = new GraphQLScalarType({
-  name: 'Upload',
-  description:
-    'The `Upload` scalar type represents a file upload promise that resolves ' +
-    'an object containing `stream`, `filename`, `mimetype` and `encoding`.',
-  parseValue: value => value,
-  parseLiteral() {
-    throw new Error('Upload scalar literal unsupported')
-  },
-  serialize() {
-    throw new Error('Upload scalar serialization unsupported')
-  }
-})
+export const createUploadType = ({ name = 'Upload' } = {}) => {
+  return new GraphQLScalarType({
+    name,
+    description:
+      'The `' +
+      name +
+      '` scalar type represents a file upload promise that resolves ' +
+      'an object containing `stream`, `filename`, `mimetype` and `encoding`.',
+    parseValue: value => value,
+    parseLiteral() {
+      throw new Error('Upload scalar literal unsupported')
+    },
+    serialize() {
+      throw new Error('Upload scalar serialization unsupported')
+    }
+  })
+}
+
+export const GraphQLUpload = createUploadType()


### PR DESCRIPTION
In my case, the `Upload` type name is already used in my schema for some high-level upload stuff, which causes type names collision. I'd like to use another type name for uploads, something like `RawUpload`. This PR adds `createUploadType` factory function, which allows passing custom props to the type constructor.

Example:

```javascript
// GraphQLUpload is still available as default type
const {GraphQLUpload} = require('apollo-upload-server')

// Custom type
const {createUploadType} = require('apollo-upload-server')
const RawUpload = createUploadType({name: 'RawUpload'})
const uploadMutation = {
  args: {file: {type: RawUpload}},
  resolve: () => { . . .}
}
```