### PR TITLE
fix: add missing dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@babel/preset-env": "^7.0.0-beta.40",
     "ava": "^1.0.0-beta.3",
     "cross-env": "^5.1.3",
+    "core-js": "^2.5.3",
     "eslint": "^4.18.2",
     "eslint-plugin-ava": "^4.5.1",
     "eslint-plugin-prettier": "^2.6.0",


### PR DESCRIPTION
After compiling, babel adds a require of `core-js` to the `/lib/middleware.js`.
However, it is not specified in package.json, so code fails when installed with
non-flat `node_modules`.