### PR TITLE
 Move @babel/runtime to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "node": ">=6.10"
   },
   "dependencies": {
-    "@babel/runtime": "7.0.0-beta.44",
     "busboy": "^0.2.14",
     "object-path": "^0.11.4"
   },
@@ -45,6 +44,7 @@
     "@babel/core": "7.0.0-beta.44",
     "@babel/plugin-transform-runtime": "7.0.0-beta.44",
     "@babel/preset-env": "7.0.0-beta.44",
+    "@babel/runtime": "7.0.0-beta.44",
     "ava": "^1.0.0-beta.4",
     "cross-env": "^5.1.5",
     "eslint": "^4.19.1",

--- a/src/middleware.mjs
+++ b/src/middleware.mjs
@@ -161,10 +161,13 @@ export const processRequest = (
     request.pipe(parser)
   })
 
-export const apolloUploadKoa = options => async (ctx, next) => {
-  if (ctx.request.is('multipart/form-data'))
-    ctx.request.body = await processRequest(ctx.req, options)
-  await next()
+export const apolloUploadKoa = options => (ctx, next) => {
+  if (!ctx.request.is('multipart/form-data')) return Promise.resolve()
+  return processRequest(ctx.req, options)
+    .then(body => {
+      ctx.request.body = body;
+      return next()
+    })
 }
 
 export const apolloUploadExpress = options => (request, response, next) => {

--- a/src/middleware.mjs
+++ b/src/middleware.mjs
@@ -168,6 +168,7 @@ export const apolloUploadKoa = options => (ctx, next) => {
       ctx.request.body = body;
       return next()
     })
+    .then(() => {})
 }
 
 export const apolloUploadExpress = options => (request, response, next) => {

--- a/src/middleware.mjs
+++ b/src/middleware.mjs
@@ -162,10 +162,11 @@ export const processRequest = (
   })
 
 export const apolloUploadKoa = options => (ctx, next) => {
-  const promise = ctx.request.is('multipart/form-data')
-    ? processRequest(ctx.req, options).then(body => { ctx.request.body = body })
-    : Promise.resolve()
-  return promise.then(body => next()).then(() => {})
+  if (!ctx.request.is('multipart/form-data')) return next()
+  return processRequest(ctx.req, options).then(body => {
+    ctx.request.body = body
+    return next()
+  })
 }
 
 export const apolloUploadExpress = options => (request, response, next) => {

--- a/src/middleware.mjs
+++ b/src/middleware.mjs
@@ -162,13 +162,10 @@ export const processRequest = (
   })
 
 export const apolloUploadKoa = options => (ctx, next) => {
-  if (!ctx.request.is('multipart/form-data')) return Promise.resolve()
-  return processRequest(ctx.req, options)
-    .then(body => {
-      ctx.request.body = body;
-      return next()
-    })
-    .then(() => {})
+  const promise = ctx.request.is('multipart/form-data')
+    ? processRequest(ctx.req, options).then(body => { ctx.request.body = body })
+    : Promise.resolve()
+  return promise.then(body => next()).then(() => {})
 }
 
 export const apolloUploadExpress = options => (request, response, next) => {


### PR DESCRIPTION
This would:
* Decrease the package size by few MB
* Decrease the RAM used by your node.js process by several MB
* Improve the startup and runtime of your node.js process by avoiding unnecessary compilation
* Fix compatibility with `nppm` package manager.
* Simplify `apollo-upload-server` maintenance for the module developer(s)

Change explanation.

Since `async` and `await` are syntactic sugar for Promises I replaced the only place we have `async/await` keywords are used with simple `.then()`.