### PR TITLE
Bump fs-capacitor to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "busboy": "^0.2.14",
-    "fs-capacitor": "^0.0.3",
+    "fs-capacitor": "^0.0.4",
     "object-path": "^0.11.4"
   },
   "devDependencies": {


### PR DESCRIPTION
I didn't realize that in semver < `1.0.0`, npm (correctly) treats all version changes as breaking.